### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "file",
     "name_pretty": "Filestore",
     "product_documentation": "https://cloud.google.com/filestore/",
-    "client_documentation": "https://googleapis.dev/python/file/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/file/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ running on Compute Engine virtual machines (VMs) instances or Google Kubernetes 
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-filestore.svg
    :target: https://pypi.org/project/google-cloud-filestore/
 .. _Filestore: https://cloud.google.com/filestore/
-.. _Client Library Documentation: https://googleapis.dev/python/file/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/file/latest
 .. _Product Documentation:  https://cloud.google.com/filestore/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.