### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-### [1.1.2](https://github.com/googleapis/python-filestore/compare/v1.1.1...v1.1.2) (2022-05-06)
+## [1.1.2](https://github.com/googleapis/python-filestore/compare/v1.1.1...v1.1.2) (2022-05-06)
 
 
 ### Documentation
 
 * fix type in docstring for map fields ([ce8c731](https://github.com/googleapis/python-filestore/commit/ce8c7315d9a7956a253f24ba41f94d645df5a06c))
 
-### [1.1.1](https://github.com/googleapis/python-filestore/compare/v1.1.0...v1.1.1) (2022-03-05)
+## [1.1.1](https://github.com/googleapis/python-filestore/compare/v1.1.0...v1.1.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -33,7 +33,7 @@
 
 * bump release level to production/stable ([#7](https://www.github.com/googleapis/python-filestore/issues/7)) ([7b30a52](https://www.github.com/googleapis/python-filestore/commit/7b30a5284bc8595d276af1224a32ff7c7c28e765))
 
-### [0.2.1](https://www.github.com/googleapis/python-filestore/compare/v0.2.0...v0.2.1) (2021-11-01)
+## [0.2.1](https://www.github.com/googleapis/python-filestore/compare/v0.2.0...v0.2.1) (2021-11-01)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.